### PR TITLE
Fix wrong composer package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WeChatWeb
 
 ```bash
-composer require socialiteproviders/wechatweb
+composer require socialiteproviders/wechat-web
 ```
 
 ## Installation & Basic Usage


### PR DESCRIPTION
For: https://github.com/SocialiteProviders/website/issues/50

Fix:
`socialiteproviders/wechatweb` does not exist, it should be `socialiteproviders/wechat-web`.